### PR TITLE
[Bugfix:Submission] Fixed improper delete permission when assignment is viewed

### DIFF
--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7801,7 +7801,8 @@ AND gc_id IN (
      */
     public function getHasBeenAccessed($gradeable_id): bool {
         $this->course_db->query(
-            'SELECT EXISTS (SELECT 1 FROM gradeable_access WHERE g_id=?)', [$gradeable_id]
+            'SELECT EXISTS (SELECT 1 FROM gradeable_access WHERE g_id=?)', 
+            [$gradeable_id]
         );
         return $this->course_db->row()['exists'];
     }

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7801,7 +7801,7 @@ AND gc_id IN (
      */
     public function getHasBeenAccessed($gradeable_id): bool {
         $this->course_db->query(
-            'SELECT EXISTS (SELECT 1 FROM gradeable_access WHERE g_id=?)', 
+            'SELECT EXISTS (SELECT 1 FROM gradeable_access WHERE g_id=?)',
             [$gradeable_id]
         );
         return $this->course_db->row()['exists'];

--- a/site/app/libraries/database/DatabaseQueries.php
+++ b/site/app/libraries/database/DatabaseQueries.php
@@ -7794,6 +7794,19 @@ AND gc_id IN (
     }
 
     /**
+     * Gets if the provided gradeable has been accessed by a student
+     *
+     * @param string $gradeable_id
+     * @return bool
+     */
+    public function getHasBeenAccessed($gradeable_id): bool {
+        $this->course_db->query(
+            'SELECT EXISTS (SELECT 1 FROM gradeable_access WHERE g_id=?)', [$gradeable_id]
+        );
+        return $this->course_db->row()['exists'];
+    }
+
+    /**
      * Get the active version for all given submitter ids. If they do not have an active version,
      * their version will be zero.
      *

--- a/site/app/models/gradeable/Gradeable.php
+++ b/site/app/models/gradeable/Gradeable.php
@@ -1797,12 +1797,20 @@ class Gradeable extends AbstractModel {
     }
 
     /**
+     * Gets if this gradeable has been accessed by any students yet
+     * @return bool
+     */
+    public function anyAccesses() {
+        return $this->core->getQueries()->getHasBeenAccessed($this->getId());
+    }
+
+    /**
      * Used to decide whether a gradeable can be deleted or not.
      * This means: No submissions, No manual grades entered, No teams formed, and No VCS repos created
      * @return bool True if the gradeable can be deleted
      */
     public function canDelete() {
-        return !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
+        return !$this->anyAccesses() && !$this->anySubmissions() && !$this->anyManualGrades() && !$this->anyTeams() && !($this->isVcs() && !$this->isTeamAssignment());
     }
 
     /**


### PR DESCRIPTION
Fixes #10916

### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [X] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Currently, if an instructor creates an assignment, and the student views but does not submit it, the delete button will still appear for the instructor. When the instructor attempts a deletion, it will lead to a database error page.

### What is the new behavior?
The viewing of the assignment will act like a submission was made for the purposes of delete checking. Meaning, the delete button no longer appears, and if an outdated delete button was pressed, it will only show a warning error popup and refresh the page.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
Tested manually using Chrome Tab for instructor and Chrome Incognito Tab for student on a Windows 11 device.
